### PR TITLE
end getopt parsing on first non-option argument

### DIFF
--- a/retry.c
+++ b/retry.c
@@ -392,7 +392,7 @@ int main (int argc, char **argv)
     long int delay = DEFAULT_DELAY;
     long int times = DEFAULT_TIMES;
 
-    while ((c = getopt_long(argc, argv, "d:m:t:u:w:hv", long_options, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "+d:m:t:u:w:hv", long_options, NULL)) != -1) {
 
         switch (c)
         {


### PR DESCRIPTION
This fixes #3 and the last section of README.md.

As GNU getopt() document says, "If the first character of optstring is '+' or the environment variable POSIXLY_CORRECT is set, then option processing stops as soon as a nonoption argument is encountered."

Tested on Ubuntu 20.04.2, there's no need to append "--" after ./retry to separate the called command.

user@vm: ~/git/retry$ ./retry echo -e hello
hello
user@vm: ~/git/retry$ ./retry echo -t hello
-t hello

BTW thanks for the work, really glad to have this tiny tool that can be directly installed on Debian/Ubuntu.
