### PR TITLE
Add a CI test

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,0 +1,51 @@
+name: full-check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install_dependencies
+      run: sudo apt install txt2man
+    - name: first_build_non_parallel
+      run: |
+           autoreconf -fi
+           ./configure
+           make; head retry.1; cat retry.1 | grep -C5 "try forever" || exit 1
+           sudo make install
+           sudo make uninstall
+           make distclean
+    - name: second_build_parallel
+      run: |
+           autoreconf -fi
+           ./configure
+           for i in 1 2 3 4 5; do make -j2; head retry.1; cat retry.1 | grep -C5 "try forever" || exit 1; make clean; done
+           sudo make install
+    - name: run_program
+      run: |
+           retry --until=success true
+           retry -t 3 -d 3 -u success ls
+           cat retry.1 | grep "try forever"
+    - name: test_make_dist
+      run: |
+           make distclean
+           autoreconf -fi -Werror -Wall
+           ./configure
+           make dist
+           mkdir test_dist
+           mv retry-*.tar.gz test_dist
+           cd test_dist
+           pwd
+           tar -xvf retry-*.tar.gz
+           rm -f retry-*.tar.gz
+           cd retry-*
+           ./configure
+           make -j2; head retry.1; cat retry.1 | grep -C5 "try forever" || exit 1
+           ls
+           sudo make install
+           sudo make uninstall
+           make distclean

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,8 @@ retry_SOURCES = retry.c
 EXTRA_DIST = retry.spec
 dist_man_MANS = retry.1
 
+CLEANFILES = retry.1
+
 retry.1: retry.c $(top_srcdir)/configure.ac
 	which txt2man && ./retry --help | txt2man -d 1 -t "${PACKAGE_NAME}" -r "${PACKAGE_NAME}-${PACKAGE_VERSION}" > retry.1 || true
 


### PR DESCRIPTION
The following tests are made:

* A single non-parallel build, followed by an install and an uninstall.
* A loop for five sequential parallel build, followed by a single install (not uninstall). This loop is needed because there is a chance of one or more builds generating a special race condition that produces a manpage correctly.
* Running the command retry over two different conditions and checking again the manpage.
* The generation of a bootstrapped tarball with make dist, followed by a single parallel build, install and uninstall to certificate the bootstrapped tarball.

All tests perform a check for the manpage integrity.

This PR is related to #12.