### PR TITLE
dist CI

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,0 +1,63 @@
+name: full-check
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install_dependencies
+      run: sudo apt install txt2man
+    - name: first_build_non_parallel
+      run: |
+           autoreconf -fi
+           ./configure
+           make
+           if [ -e retry.1 ]
+           then
+                echo "ERROR: found a manpage."
+                exit 1
+           fi
+           sudo make install
+           sudo make uninstall
+           make distclean
+    - name: second_build_parallel
+      run: |
+           autoreconf -fi
+           ./configure
+           for i in 1 2 3 4 5
+           do
+                make -j2
+                if [ -e retry.1 ]
+                then
+                     echo "ERROR: found a manpage."
+                     exit 1
+                fi
+           done
+           sudo make install
+    - name: run_program
+      run: |
+           retry --until=success true
+           retry -t 3 -d 3 -u success ls
+    - name: test_make_dist
+      run: |
+           make distclean
+           autoreconf -fi -Werror -Wall
+           ./configure
+           make dist
+           mkdir test_dist
+           mv retry-*.tar.gz test_dist
+           cd test_dist
+           pwd
+           tar -xvf retry-*.tar.gz
+           rm -f retry-*.tar.gz
+           cd retry-*
+           ./configure
+           make -j2; head retry.1; cat retry.1 | grep -C5 "try forever" || exit 1
+           ls
+           sudo make install
+           sudo make uninstall
+           make distclean

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,10 @@
 
+Changes with v1.0.6
+
+  *) Generate the man page during the dist hook, and not
+     at build time. This makes life easy for parallel and
+     cross compiled builds. [Graham Leggett]
+
 Changes with v1.0.5
 
   *) End getopt parsing on first non-option argument.

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,9 @@ retry_SOURCES = retry.c
 EXTRA_DIST = retry.spec
 dist_man_MANS = retry.1
 
-retry.1: retry.c $(top_srcdir)/configure.ac
-	which txt2man && ./retry --help | txt2man -d 1 -t "${PACKAGE_NAME}" -r "${PACKAGE_NAME}-${PACKAGE_VERSION}" > retry.1 || true
+dist-hook: retry.1
+	install retry.1 $(distdir)/retry.1
+
+retry.1: retry
+	./retry --help | txt2man -d 1 -t "${PACKAGE_NAME}" -r "${PACKAGE_NAME}-${PACKAGE_VERSION}" > retry.1
 

--- a/config.h.in
+++ b/config.h.in
@@ -13,14 +13,14 @@
    to 0 otherwise. */
 #undef HAVE_MALLOC
 
-/* Define to 1 if you have the <memory.h> header file. */
-#undef HAVE_MEMORY_H
-
 /* Define to 1 if stdbool.h conforms to C99. */
 #undef HAVE_STDBOOL_H
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#undef HAVE_STDIO_H
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #undef HAVE_STDLIB_H
@@ -67,7 +67,9 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #undef STDC_HEADERS
 
 /* Version number of package */
@@ -87,7 +89,7 @@
 /* Define to rpl_malloc if the replacement function should be used. */
 #undef malloc
 
-/* Define to `int' if <sys/types.h> does not define. */
+/* Define as a signed integer type capable of holding a process identifier. */
 #undef pid_t
 
 /* Define to `unsigned int' if <sys/types.h> does not define. */

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT(retry, 1.0.5, minfrin@sharp.fm)
+AC_INIT(retry, 1.0.6, minfrin@sharp.fm)
 AC_CONFIG_AUX_DIR(build-aux)
 AC_CONFIG_MACRO_DIRS([m4])
 AM_INIT_AUTOMAKE([dist-bzip2])


### PR DESCRIPTION
This PR implements a CI test for dist branch. This test will fail if a manpage has been generated without the ```make dist``` command or if other trivial error occurs.